### PR TITLE
feat: add ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  pull_request:
+
+jobs:
+  make-lint-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - run: make lint-go
+  make-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - run: make build
+  make-lint-shell:
+    runs-on: ubuntu-latest
+    steps:
+      - run: make lint-shell
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts
+          node-version: 18
       - run: npm install -g markdownlint-cli
       - run: make lint-markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make lint-shell
-
+  make-lint-markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts
+      - run: npm install -g markdownlint-cli
+      - run: make lint-markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,22 @@ jobs:
   make-lint-go:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version-file: './go.mod'
       - run: make lint-go
   make-build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version-file: './go.mod'
       - run: make build
   make-lint-shell:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - run: make lint-shell
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+MD013: false
+MD012: false
+MD024: false

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,18 @@ decrypt:
 	@./scripts/sops.sh $@
 encrypt:
 	@./scripts/sops.sh $@
+
+# ci
+lint: lint-shell lint-go
+
+lint-shell:
+	@shellcheck --color=always scripts/*
+
+lint-go: lint-go-setup
+	@staticcheck ./...
+
+lint-go-setup:
+	@go install honnef.co/go/tools/cmd/staticcheck@latest
+
+build:
+	@go build

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 # elyclover.com-infra
 
 # targets to handle SOPS encryption/decryption using Azure keyvault
@@ -7,7 +9,7 @@ encrypt:
 	@./scripts/sops.sh $@
 
 # ci
-lint: lint-shell lint-go
+lint: lint-shell lint-go lint-markdown
 
 lint-shell:
 	@shellcheck --color=always scripts/*
@@ -17,6 +19,14 @@ lint-go: lint-go-setup
 
 lint-go-setup:
 	@go install honnef.co/go/tools/cmd/staticcheck@latest
+
+lint-markdown:
+	@IFS=$$'\n' && \
+	MDFILES=($$(find . -name "*.md")) && \
+	unset IFS && \
+	for f in "$${MDFILES[@]}"; do \
+	  markdownlint "$$f"; \
+	done
 
 build:
 	@go build

--- a/keyvault.go
+++ b/keyvault.go
@@ -10,6 +10,8 @@ import (
 )
 
 // look up an AZ Key Vault Secret by name
+//
+//lint:ignore U1000 external type doesn't have compatible string method
 func getSecretByName(ctx *pulumi.Context, kv string, rg string, name string) (secret *keyvault.LookupSecretResult, err error) {
 	secret, err = keyvault.LookupSecret(ctx, &keyvault.LookupSecretArgs{
 		VaultName:         kv,

--- a/scripts/pem-to-pfx.sh
+++ b/scripts/pem-to-pfx.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 # convert a pem cert to pfx type as Azure Key Vault would prefer them
-INKEY=$1
-INCRT=$2
-OUTPFX=$3
 
 echo "ex: ./pem-to-pfx.sh yourkey.key yourcrt.crt outpfx.pfx"
 


### PR DESCRIPTION
Adds static analysis checks via Makefile targets for:

- go
- markdown
- shell

It also adds a `make build` step that compiles the go/pulumi application.

Intermediate setup steps were also added to ensure this is repeatable in CI.